### PR TITLE
improved lights on bootup

### DIFF
--- a/neuralert/src/apps/user_apps.c
+++ b/neuralert/src/apps/user_apps.c
@@ -77,7 +77,7 @@ static void user_wifi_disconn(void *arg);
 extern void	tcp_client_sleep2_sample(void *param);
 extern void user_start_MQTT_client();
 extern void user_terminate_transmit();
-extern UINT8 system_state_clear();
+extern UINT8 check_mqtt_block();
 
 /******************************************************************************
  * Local variables
@@ -140,10 +140,10 @@ static void user_wifi_conn(void *arg)
             xEventGroupClearBits(evt_grp_wifi_conn_notify, WIFI_CONN_SUCC_STA);
 
             PRINTF("\n### User Call-back : Success to connect Wi-Fi ...\n");
-            if (system_state_clear()) {
-                user_start_MQTT_client();
+            if (check_mqtt_block()) {
+                PRINTF("\n### MQTT block enabled\n");
             } else {
-                PRINTF("\n### System State not clear : Not attempting MQTT connection\n");
+                user_start_MQTT_client();
             }
 
             


### PR DESCRIPTION
Changed the light to blink yellow until data is received by MQTT broker.  This required:
1) changing light colors
2) blocking the device from going to sleep until successful transmission
3) created the first transmission to include only a few seconds of data (so we don't have to wait a minute)

