### PR TITLE
edits to allow GPIO_INIT to be called multiple times

### DIFF
--- a/neuralert/src/apps/user_gpio_handle.c
+++ b/neuralert/src/apps/user_gpio_handle.c
@@ -64,8 +64,8 @@ int set_gpio_interrupt(void)
     }
 
     if (!GPIO_INIT(hgpio)) {
-        PRINTF("[%s] GPIO_INIT failed\n", __func__);
-        return FALSE;
+        // GPIO_INIT will fail if the GPIO_UNIT_A was already initialized, we can ignore since hgpio is not NULL
+        PRINTF("[%s] GPIO_INIT(hgpio) already initialized\n", __func__);
     }
 
     if (!GPIO_IOCTL(hgpio, GPIO_SET_INPUT, &io)) {

--- a/neuralert/src/user_main/system_start.c
+++ b/neuralert/src/user_main/system_start.c
@@ -458,8 +458,8 @@ void trigger_mcu_wakeup_gpio(void)
             return;
         }
         if (!GPIO_INIT(gpio)) {
-            PRINTF("[%s] GPIO_INIT(gpio) failed\n", __func__);
-            return;
+            // GPIO_INIT will fail if the GPIO_UNIT_A was already initialized, we can ignore since gpio is not NULL
+            PRINTF("[%s] GPIO_INIT(gpio) already initialized\n", __func__);
         }
 
         pin = GPIO_PIN11;

--- a/neuralert/src/user_main/user_main.c
+++ b/neuralert/src/user_main/user_main.c
@@ -126,10 +126,11 @@ int config_pin_mux(void)
 	if (gpioc == NULL) {
 		PRINTF("[%s] GPIO_CREATE(GPIO_UNIT_C) failed\n", __func__);
 		return FALSE;
-	}
+	} 
+
 	if (!GPIO_INIT(gpioc)) {
-		PRINTF("[%s] GPIO_INIT(gpioc) failed\n", __func__);
-		return FALSE;
+		// GPIO_INIT will fail if the GPIO_UNIT_C was already initialized, we can ignore since gpioc is not NULL
+		PRINTF("[%s] GPIO_INIT(gpioc) already initialized\n", __func__);
 	}
 
 	pin = GPIO_PIN6 | GPIO_PIN7 | GPIO_PIN8;
@@ -159,8 +160,8 @@ int config_pin_mux(void)
 		return FALSE;
 	}
 	if (!GPIO_INIT(gpioa)) {
-		PRINTF("[%s] GPIO_INIT(gpioa) failed\n", __func__);
-		return FALSE;
+		// GPIO_INIT will fail if the GPIO_UNIT_A was already initialized, we can ignore since gpioa is not NULL
+		PRINTF("[%s] GPIO_INIT(gpioa) already initialized\n", __func__);
 	}
 	/*
 	 * GPIOA[10] output high


### PR DESCRIPTION
This patch allows for GPIO_INIT to be called multiple times without failure -- sdk allows for this functionality in examples.  No immediate risk as long as the input to GPIO_INIT is checked for NULL prior to execution.