### PR TITLE
increased the maximum size of provisioning buffer to 10k

### DIFF
--- a/neuralert/include/user_main/common.h
+++ b/neuralert/include/user_main/common.h
@@ -482,8 +482,12 @@ typedef uint32_t _AB_transmit_map_t;
 #define TCP_CLIENT_DEF_SERVER_PORT		TCP_SERVER_DEF_PORT
 
 #define TCP_PROVISION_PORT_NUM			9999
-#define PROVISION_TCP_RX_BUF_SZ			1024
 
+// This is the size of the buffer for receiving provisioning data over TCP.  
+// It needs to be large enough to hold the provisioning data, which includes the WiFi SSID and password, 
+// and any other configuration data we want to send during provisioning.  
+// The exact size needed will depend on the format of the provisioning data, but 10 KB should be sufficient for typical use cases.
+#define PROVISION_TCP_RX_BUF_SZ			(1024 * 10) 
 
 // Provisioning Defs
 #define APP_SOFTAP_PROV_NAME			"APROV_TCP"

--- a/neuralert/src/apps/neuralert.c
+++ b/neuralert/src/apps/neuralert.c
@@ -4374,8 +4374,9 @@ void tcp_server_thread(void *arg)
 				}
 
 				// Cap msg_len to maximum buffer size
-				if (msg_len > TCP_SERVER_DEF_BUF_SIZE) {
-					msg_len = TCP_SERVER_DEF_BUF_SIZE;
+				if (msg_len > PROVISION_TCP_RX_BUF_SZ) {
+					PRINTF("[%s] Provisioning Message too long -- aborting: %d > %d\r\n", __func__, msg_len, PROVISION_TCP_RX_BUF_SZ);
+					break;
 				}
 
 				vTaskDelay(3);


### PR DESCRIPTION
The provisioning message is typically 2k to 3k in length -- setting the max buffer to 10k