### PR TITLE
Added xSemaphoreGive after xSemaphoreCreateBinary

### DIFF
--- a/neuralert/src/drivers/W25QXX.c
+++ b/neuralert/src/drivers/W25QXX.c
@@ -94,6 +94,9 @@ HANDLE flash_open(UINT32 spi_clock, UINT32 spi_cs) {
 		_spi_flash_semaphore = xSemaphoreCreateBinary();
 	}
 	configASSERT(_spi_flash_semaphore);
+
+
+	
 //	configASSERT(xSemaphoreTake(_spi_flash_semaphore, 10000 / portTICK_PERIOD_MS) == pdTRUE);
 	xSemaphoreTake(_spi_flash_semaphore, portMAX_DELAY);
 


### PR DESCRIPTION
see semphr.h for reasoning ... looks like vSemaphore was deprecated and the new xSemaphoreCreateBinary requires an attempted "Give" prior to "Take".